### PR TITLE
Bump version and use renamed API

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": "Lars Grammel",
   "license": "MIT",
   "dependencies": {
-    "modelfusion": "^0.47.1",
+    "modelfusion": "^0.51.0",
     "zod": "^3.22.4",
     "zod-to-json-schema": "^3.21.4",
     "dotenv": "16.3.1"

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,11 @@
 import dotenv from "dotenv";
-import { OpenAITextGenerationModel, streamText } from "modelfusion";
+import { OpenAICompletionModel, streamText } from "modelfusion";
 
 dotenv.config();
 
 async function main() {
   const textStream = await streamText(
-    new OpenAITextGenerationModel({
+    new OpenAICompletionModel({
       model: "gpt-3.5-turbo-instruct",
       maxCompletionTokens: 500,
     }),


### PR DESCRIPTION
Uses `OpenAICompletionModel` instead of `OpenAITextGenerationModel`.
